### PR TITLE
Improve FromBigInt performance

### DIFF
--- a/leb128_test.go
+++ b/leb128_test.go
@@ -94,6 +94,13 @@ func TestFromBigInt(t *testing.T) {
 	}
 }
 
+func BenchmarkFromBigInt(b *testing.B) {
+	val := int64(2141192192)
+	for n := 0; n < b.N; n++ {
+		FromBigInt(big.NewInt(val))
+	}
+}
+
 func TestFromBigIntIsNotDestructive(t *testing.T) {
 	assert := assert.New(t)
 


### PR DESCRIPTION
This PR significantly increases the memory and CPU performance of `FromBigInt` by using an internal pool of `big.Int` objects. Performance numbers are below:

```
BEFORE:

BenchmarkFromBigInt-8            2000000               753 ns/op             824 B/op         22 allocs/op
PASS
ok      github.com/filecoin-project/go-leb128   2.312s


AFTER:

BenchmarkFromBigInt-8            5000000               360 ns/op             168 B/op          5 allocs/op
PASS
ok      github.com/filecoin-project/go-leb128   2.215s
```